### PR TITLE
Fix hdbscan build issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas==2.1.1
 path==16.7.1
 sentence-transformers==2.2.2
 spacy==3.7.0
-hdbscan==0.8.29
+hdbscan==0.8.33
 bertopic==0.15.0
 tqdm==4.66.1
 langchain==0.0.308


### PR DESCRIPTION
Got errors when `pip install -r requirements.txt` on my `Apple Silicon M2`

```
error: failed building wheel for hdbscan
...
```

Fixed by upgrading hdbscan
