### PR TITLE
Style tweaks

### DIFF
--- a/next-app/components/Appendix.tsx
+++ b/next-app/components/Appendix.tsx
@@ -12,7 +12,7 @@ const Appendix = ({ config, translator }: Props) => {
   const steps = ['extraction', 'embedding', 'clustering', 'labelling', 'takeaways', 'overview']
   return <div id="appendix">
     <hr className="h-px my-8 bg-gray-600 border-0 dark:bg-gray-700"></hr>
-    <h2 className='text-3xl font-bold my-4 border-t-black'>{t("Appendix")}</h2>
+    <h2 className='text-3xl my-4 border-t-black'>{t("Appendix")}</h2>
     <div className='text-left mt-8'>
       {t("This report was generated using an AI pipeline that consists of the following steps")}:
       <div className="text-left list-outside list-disc ml-6 mt-4">

--- a/next-app/components/Header.tsx
+++ b/next-app/components/Header.tsx
@@ -11,7 +11,7 @@ const Header = (props: HeaderProps) => {
   const { t, languages, langIndex, setLangIndex } = props.translator
   const { hasTranslations } = useInferredFeatures(props)
 
-  return <div className='fixed top-0 w-full h-7 bg-gradient-to-r from-blue-900 to-white z-10 leading-7'>
+  return <div className='fixed top-0 w-full px-2 bg-blue-900 z-10 leading-10'>
     <div className="flex justify-between">
       <div className="text-white mx-2">
         Talk to the City
@@ -23,7 +23,7 @@ const Header = (props: HeaderProps) => {
           key={lang.name}
           onClick={() => setLangIndex(i)}
         >
-          <img className="w-5 inline-block leading-5 pb-[4px] hover:shadow-2xl shadow-white"
+          <img className="w-5 inline-block leading-5 hover:shadow-2xl shadow-white"
             src={`https://purecatamphetamine.github.io/country-flag-icons/3x2/${lang.flag}.svg`} alt="" />
           {/* {t(lang.name)} */}
         </button>)}

--- a/next-app/components/Outline.tsx
+++ b/next-app/components/Outline.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 const Section = ({ name, target, small }: { name: string, target: string, small?: boolean }) => {
   let className = "opacity-60 hover:opacity-100 cursor-pointer"
-  if (small) className += " text-xs ml-2 max-w-xs  line-clamp-1 leading-6"
+  if (small) className += " text-xs ml-2 max-w-xs line-clamp-1 leading-6"
   return <h2 className={className} onClick={() => {
     const elem = document.getElementById(target)!
     window.scrollTo({ top: elem.offsetTop - 50, behavior: 'smooth' })

--- a/next-app/components/Outline.tsx
+++ b/next-app/components/Outline.tsx
@@ -17,7 +17,7 @@ const Section = ({ name, target, small }: { name: string, target: string, small?
 
 const Outline = ({ clusters, translator }: Props) => {
   const { t } = translator
-  return <div className='hidden xl:block fixed left-0 top-0 h-full text-left mt-8 opacity-40 hover:opacity-100 leading-10 transition-all'>
+  return <div className='hidden xl:block fixed left-0 top-0 h-full text-left mt-8 leading-10'>
     <div className="text-left list-outside list-disc ml-2 mt-4">
       <Section name={t("Introduction")!} target="introduction" />
       <Section name={t("Clusters")!} target="clusters" />

--- a/next-app/components/Outline.tsx
+++ b/next-app/components/Outline.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 const Section = ({ name, target, small }: { name: string, target: string, small?: boolean }) => {
   let className = "opacity-60 hover:opacity-100 cursor-pointer"
-  if (small) className += " text-xs ml-2  max-w-xs  line-clamp-1 leading-6"
+  if (small) className += " text-xs ml-2 max-w-xs  line-clamp-1 leading-6"
   return <h2 className={className} onClick={() => {
     const elem = document.getElementById(target)!
     window.scrollTo({ top: elem.offsetTop - 50, behavior: 'smooth' })
@@ -17,8 +17,9 @@ const Section = ({ name, target, small }: { name: string, target: string, small?
 
 const Outline = ({ clusters, translator }: Props) => {
   const { t } = translator
-  return <div className='hidden xl:block fixed left-0 top-0 h-full text-left mt-8 leading-10'>
-    <div className="text-left list-outside list-disc ml-2 mt-4">
+  return <div className='hidden lg:block sticky left-0 top-10 pr-4 pl-4 text-left
+                         leading-10 bg-gray-100 h-[calc(100vh-2.5rem)]'>
+    <div className="text-left list-outside list-disc mt-4">
       <Section name={t("Introduction")!} target="introduction" />
       <Section name={t("Clusters")!} target="clusters" />
       {clusters.map((cluster, i) => <Section small key={i} name={t(cluster.cluster)!}

--- a/next-app/components/Report.tsx
+++ b/next-app/components/Report.tsx
@@ -37,17 +37,17 @@ function Report(props: ReportProps) {
   return <div className='mt-9'>
     <Outline clusters={clusters} translator={translator} />
     <Header {...props} translator={translator} />
-    <div className='text-center max-w-3xl m-auto py-8 px-5'
+    <div className='max-w-3xl m-auto py-8 px-5'
       style={{ display: openMap ? 'none' : 'block' }}>
-      <h2 className='text-xl my-3 font-bold'>{t(config.name)}</h2>
-      <h1 className='text-3xl my-3 mb-10'>{t(config.question)}</h1>
+      <h2 className='text-xl my-3 font-light'>{t(config.name)}</h2>
+      <h1 className='text-3xl my-3 mb-6'>{t(config.question)}</h1>
 
       <div id="introduction" className='my-4'>
         {config.intro &&
-          <div className='max-w-xl m-auto mb-4 text-justify italic' dangerouslySetInnerHTML={{
+          <div className='max-w-3xl m-auto mb-10 text-justify italic' dangerouslySetInnerHTML={{
             __html: converter.makeHtml(t(config.intro)!)
           }} />}
-        <div id="big-map">
+        <div id="big-map" className="mb-10">
           <Map {...props} translator={translator} color={color} width={450} height={450} />
           <button className="my-2 underline"
             onClick={() => {
@@ -60,18 +60,18 @@ function Report(props: ReportProps) {
             }}>
             {t("Open full-screen map")}</button>
         </div>
-        <div id="overview" className='text-left font-bold my-3'>{t("Overview")}:</div>
-        <div className='text-left'>{t(overview)}</div>
+        <div id="overview" className='text-xl font-semibold my-3'>{t("Overview")}:</div>
+        <div>{t(overview)}</div>
       </div>
       <div id="clusters">
         {clusters.sort((c1, c2) => c2.arguments.length - c1.arguments.length)
           .map((cluster) => <div key={cluster.cluster_id} id={`cluster-${cluster.cluster_id}`}>
-            <h2 className="text-2xl font-semibold my-2 mt-12"
+            <h2 className="text-2xl font-semibold my-1 mt-12"
               style={{ color: color(cluster.cluster_id) }}>{t(cluster.cluster)}</h2>
-            <div className="text-lg opacity-50 mb-3">({cluster.arguments.length} {t("arguments")},
+            <div className="opacity-50 mb-4">({cluster.arguments.length} {t("arguments")},&nbsp;
               {Math.round(100 * cluster.arguments.length / totalArgs)}% {t("of total")})</div>
-            <div className='text-left font-bold my-3'>{t("Cluster analysis")}:</div>
-            <div className='text-left'>{t(cluster.takeaways)}</div>
+            <div className='text-lg font-semibold my-3 mt-5'>{t("Cluster analysis")}</div>
+            <div>{t(cluster.takeaways)}</div>
             <div className='my-4'>
               <Map  {...props} translator={translator} color={color} width={350} height={350} onlyCluster={t(cluster.cluster_id)} />
               <button className="my-2 underline" onClick={() => {
@@ -83,8 +83,8 @@ function Report(props: ReportProps) {
                 }
               }}>{t("Open full-screen map")}</button>
             </div>
-            <div className='text-left font-bold my-3'>{t("Representative comments")}:</div>
-            <ul className='text-left list-outside list-disc ml-6 '>
+            <div className='text-lg font-semibold my-6'>{t("Representative comments")}</div>
+            <ul className='list-outside list-disc ml-6 '>
               {cluster.arguments
                 .sort((a, b) => b.p - a.p)
                 .slice(0, 5).map((arg, i) =>

--- a/next-app/components/Report.tsx
+++ b/next-app/components/Report.tsx
@@ -69,7 +69,7 @@ function Report(props: ReportProps) {
             .map((cluster) => <div key={cluster.cluster_id} id={`cluster-${cluster.cluster_id}`}>
               <h2 className="text-2xl font-semibold my-1 mt-12"
                 style={{ color: color(cluster.cluster_id) }}>{t(cluster.cluster)}</h2>
-              <div className="opacity-50 mb-4">({cluster.arguments.length} {t("arguments")},%nbsp;
+              <div className="opacity-50 mb-4">({cluster.arguments.length} {t("arguments")},&nbsp;
                 {Math.round(100 * cluster.arguments.length / totalArgs)}% {t("of total")})</div>
               <div className='text-lg font-semibold my-3 mt-5'>{t("Cluster analysis")}</div>
               <div>{t(cluster.takeaways)}</div>

--- a/next-app/components/Report.tsx
+++ b/next-app/components/Report.tsx
@@ -61,7 +61,7 @@ function Report(props: ReportProps) {
               }}>
               {t("Open full-screen map")}</button>
           </div>
-          <div id="overview" className='text-xl font-semibold my-3'>{t("Overview")}:</div>
+          <div id="overview" className='text-xl font-semibold my-3'>{t("Overview")}</div>
           <div>{t(overview)}</div>
         </div>
         <div id="clusters">
@@ -69,7 +69,7 @@ function Report(props: ReportProps) {
             .map((cluster) => <div key={cluster.cluster_id} id={`cluster-${cluster.cluster_id}`}>
               <h2 className="text-2xl font-semibold my-1 mt-12"
                 style={{ color: color(cluster.cluster_id) }}>{t(cluster.cluster)}</h2>
-              <div className="opacity-50 mb-4">({cluster.arguments.length} {t("arguments")},&nbsp;
+              <div className="opacity-50 mb-4">({cluster.arguments.length} {t("arguments")},%nbsp;
                 {Math.round(100 * cluster.arguments.length / totalArgs)}% {t("of total")})</div>
               <div className='text-lg font-semibold my-3 mt-5'>{t("Cluster analysis")}</div>
               <div>{t(cluster.takeaways)}</div>

--- a/next-app/components/Report.tsx
+++ b/next-app/components/Report.tsx
@@ -35,65 +35,67 @@ function Report(props: ReportProps) {
     }} fullScreen onlyCluster={openMap !== 'main' ? openMap : undefined} />
   }
   return <div className='mt-9'>
-    <Outline clusters={clusters} translator={translator} />
     <Header {...props} translator={translator} />
-    <div className='max-w-3xl m-auto py-8 px-5'
-      style={{ display: openMap ? 'none' : 'block' }}>
-      <h2 className='text-xl my-3 font-light'>{t("Project") + ": " + t(config.name)}</h2>
-      <h1 className='text-3xl my-3 mb-6'>{t(config.question)}</h1>
+    <div className="flex">
+      <Outline clusters={clusters} translator={translator} />
+      <div className='max-w-3xl m-auto py-8 px-8'
+        style={{ display: openMap ? 'none' : 'block' }}>
+        <h2 className='text-xl my-3 font-light'>{t("Project") + ": " + t(config.name)}</h2>
+        <h1 className='text-3xl my-3 mb-6'>{t(config.question)}</h1>
 
-      <div id="introduction" className='my-4'>
-        {config.intro &&
-          <div className='max-w-3xl m-auto mb-10 text-justify italic' dangerouslySetInnerHTML={{
-            __html: converter.makeHtml(t(config.intro)!)
-          }} />}
-        <div id="big-map" className="mb-10">
-          <Map {...props} translator={translator} color={color} width={450} height={450} />
-          <button className="my-2 underline"
-            onClick={() => {
-              if (isTouchDevice()) {
-                alert('Our interactive maps are not yet available on touch devices. Please try again from a desktop computer.')
-              } else {
-                scroll.current = window.scrollY
-                setOpenMap("main")
-              }
-            }}>
-            {t("Open full-screen map")}</button>
-        </div>
-        <div id="overview" className='text-xl font-semibold my-3'>{t("Overview")}:</div>
-        <div>{t(overview)}</div>
-      </div>
-      <div id="clusters">
-        {clusters.sort((c1, c2) => c2.arguments.length - c1.arguments.length)
-          .map((cluster) => <div key={cluster.cluster_id} id={`cluster-${cluster.cluster_id}`}>
-            <h2 className="text-2xl font-semibold my-1 mt-12"
-              style={{ color: color(cluster.cluster_id) }}>{t(cluster.cluster)}</h2>
-            <div className="opacity-50 mb-4">({cluster.arguments.length} {t("arguments")},&nbsp;
-              {Math.round(100 * cluster.arguments.length / totalArgs)}% {t("of total")})</div>
-            <div className='text-lg font-semibold my-3 mt-5'>{t("Cluster analysis")}</div>
-            <div>{t(cluster.takeaways)}</div>
-            <div className='my-4'>
-              <Map  {...props} translator={translator} color={color} width={350} height={350} onlyCluster={t(cluster.cluster_id)} />
-              <button className="my-2 underline" onClick={() => {
+        <div id="introduction" className='my-4'>
+          {config.intro &&
+            <div className='max-w-3xl m-auto mb-10 text-justify italic' dangerouslySetInnerHTML={{
+              __html: converter.makeHtml(t(config.intro)!)
+            }} />}
+          <div id="big-map" className="mb-10">
+            <Map {...props} translator={translator} color={color} width={450} height={450} />
+            <button className="block my-2 mx-auto bg-gray-100 py-2 px-3 rounded-sm"
+              onClick={() => {
                 if (isTouchDevice()) {
                   alert('Our interactive maps are not yet available on touch devices. Please try again from a desktop computer.')
                 } else {
                   scroll.current = window.scrollY
-                  setOpenMap(cluster.cluster_id)
+                  setOpenMap("main")
                 }
-              }}>{t("Open full-screen map")}</button>
-            </div>
-            <div className='text-lg font-semibold my-6'>{t("Representative comments")}</div>
-            <ul className='list-outside list-disc ml-6 '>
-              {cluster.arguments
-                .sort((a, b) => b.p - a.p)
-                .slice(0, 5).map((arg, i) =>
-                  <li key={i} className='italic'>{t(arg.argument)}</li>
-                )}
-            </ul>
-          </div>)}
+              }}>
+              {t("Open full-screen map")}</button>
+          </div>
+          <div id="overview" className='text-xl font-semibold my-3'>{t("Overview")}:</div>
+          <div>{t(overview)}</div>
+        </div>
+        <div id="clusters">
+          {clusters.sort((c1, c2) => c2.arguments.length - c1.arguments.length)
+            .map((cluster) => <div key={cluster.cluster_id} id={`cluster-${cluster.cluster_id}`}>
+              <h2 className="text-2xl font-semibold my-1 mt-12"
+                style={{ color: color(cluster.cluster_id) }}>{t(cluster.cluster)}</h2>
+              <div className="opacity-50 mb-4">({cluster.arguments.length} {t("arguments")},&nbsp;
+                {Math.round(100 * cluster.arguments.length / totalArgs)}% {t("of total")})</div>
+              <div className='text-lg font-semibold my-3 mt-5'>{t("Cluster analysis")}</div>
+              <div>{t(cluster.takeaways)}</div>
+              <div className='my-4'>
+                <Map  {...props} translator={translator} color={color} width={350} height={350} onlyCluster={t(cluster.cluster_id)} />
+                <button className="block my-2 mx-auto bg-gray-100 py-2 px-3 rounded-sm" onClick={() => {
+                  if (isTouchDevice()) {
+                    alert('Our interactive maps are not yet available on touch devices. Please try again from a desktop computer.')
+                  } else {
+                    scroll.current = window.scrollY
+                    setOpenMap(cluster.cluster_id)
+                  }
+                }}>{t("Open full-screen map")}</button>
+              </div>
+              <div className='text-lg font-semibold my-6'>{t("Representative comments")}</div>
+              <ul className='list-outside list-disc ml-6 '>
+                {cluster.arguments
+                  .sort((a, b) => b.p - a.p)
+                  .slice(0, 5).map((arg, i) =>
+                    <li key={i} className='italic'>{t(arg.argument)}</li>
+                  )}
+              </ul>
+            </div>)}
+        </div>
+        <Appendix config={config} translator={translator} />
       </div>
-      <Appendix config={config} translator={translator} />
     </div>
   </div>
 }

--- a/next-app/components/Report.tsx
+++ b/next-app/components/Report.tsx
@@ -39,7 +39,7 @@ function Report(props: ReportProps) {
     <Header {...props} translator={translator} />
     <div className='max-w-3xl m-auto py-8 px-5'
       style={{ display: openMap ? 'none' : 'block' }}>
-      <h2 className='text-xl my-3 font-light'>{t(config.name)}</h2>
+      <h2 className='text-xl my-3 font-light'>{t("Project") + ": " + t(config.name)}</h2>
       <h1 className='text-3xl my-3 mb-6'>{t(config.question)}</h1>
 
       <div id="introduction" className='my-4'>

--- a/next-app/globals.css
+++ b/next-app/globals.css
@@ -38,35 +38,13 @@ body {
 
 
 /* outline */
-.hidden.fixed.left-0.top-0.h-full.text-left.mt-8.leading-10 {
+.fixed.left-0.top-0.h-full.text-left.mt-8.leading-10 {
     background-color: rgb(243 244 246);
     padding-right: 1rem;
     padding-left: 0.5rem;
-    line-height: 40px !important;
 }
 
-/* header */
-.fixed.top-0.w-full.h-7.z-10.leading-7 {
-    height: 40px !important;
-    background-color: hsl(222 59% 39% / 1) !important;
-    line-height: 40px !important;
-}
-
-.flex.justify-between {
-    padding: 0 .5rem;
-}
-
-.text-white.mx-2 {
-    margin-top: auto;
-    margin-bottom: auto;
-    line-height: 40px !important;
-}
-
-img.w-5.inline-block.leading-5.shadow-white {
-    padding-bottom: 0;
-}
-
-/* report */
+/* full-screen map buttons */
 button.my-2.underline {
     display: block;
     margin-left: auto;

--- a/next-app/globals.css
+++ b/next-app/globals.css
@@ -20,3 +20,60 @@ html,
 body {
   overscroll-behavior: none;
 }
+
+
+/* Colleen scratchpad
+ * TODO(colleemn) move to tailwind in components after checking styles
+ */
+
+/* tailwind overrides */
+.text-xl {
+  font-size: 1.25rem !important
+}
+
+.text-3xl {
+    font-size: 2rem;
+    line-height: 2.75rem;
+}
+
+
+/* outline */
+.hidden.fixed.left-0.top-0.h-full.text-left.mt-8.leading-10 {
+    background-color: rgb(243 244 246);
+    padding-right: 1rem;
+    padding-left: 0.5rem;
+    line-height: 40px !important;
+}
+
+/* header */
+.fixed.top-0.w-full.h-7.z-10.leading-7 {
+    height: 40px !important;
+    background-color: hsl(222 59% 39% / 1) !important;
+    line-height: 40px !important;
+}
+
+.flex.justify-between {
+    padding: 0 .5rem;
+}
+
+.text-white.mx-2 {
+    margin-top: auto;
+    margin-bottom: auto;
+    line-height: 40px !important;
+}
+
+img.w-5.inline-block.leading-5.shadow-white {
+    padding-bottom: 0;
+}
+
+/* report */
+button.my-2.underline {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    text-decoration: none;
+    background-color: #eee;
+    padding: 0.5rem 0.75rem;
+    border-radius: 2px;
+}
+

--- a/next-app/globals.css
+++ b/next-app/globals.css
@@ -21,12 +21,7 @@ body {
   overscroll-behavior: none;
 }
 
-
-/* Colleen scratchpad
- * TODO(colleemn) move to tailwind in components after checking styles
- */
-
-/* tailwind overrides */
+/* Tailwind overrides */
 .text-xl {
   font-size: 1.25rem !important
 }
@@ -34,24 +29,5 @@ body {
 .text-3xl {
     font-size: 2rem;
     line-height: 2.75rem;
-}
-
-
-/* outline */
-.fixed.left-0.top-0.h-full.text-left.mt-8.leading-10 {
-    background-color: rgb(243 244 246);
-    padding-right: 1rem;
-    padding-left: 0.5rem;
-}
-
-/* full-screen map buttons */
-button.my-2.underline {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-    text-decoration: none;
-    background-color: #eee;
-    padding: 0.5rem 0.75rem;
-    border-radius: 2px;
 }
 

--- a/next-app/hooks/useClusterColor.ts
+++ b/next-app/hooks/useClusterColor.ts
@@ -1,30 +1,30 @@
 import { useCallback, useMemo } from "react";
 
 const colors: string[] = [
-  "#8a2be2", // Purple
-  "#ff69b4", // Pink
-  "#1e90ff", // Blue
-  "#008080", // Teal
-  "#00d3d3", // Cyan
-  "#cdcd00", // Yellow
+  "#4169e1", // Royal Blue
+  "#ff6347", // Tomato
+  "#2e8b57", // Sea Green
+  "#dc143c", // Crimson
   "#ffa500", // Orange
-  "#ff0000", // Red
-  "#008000", // Green
+  "#8a2be2", // Purple
+  "#8b4513", // Saddle Brown
+  "#ff69b4", // Pink
+  "#00d3d3", // Cyan
+  "#556b2f", // Dark Olive Green
+  "#cdcd00", // Yellow
+  "#1e90ff", // Blue
   "#ff4500", // Orange-Red
   "#32cd32", // Lime Green
-  "#ff1493", // Deep Pink
-  "#9932cc", // Dark Orchid
-  "#20b2aa", // Light Sea Green
-  "#ff6347", // Tomato
-  "#4169e1", // Royal Blue
-  "#2e8b57", // Sea Green
-  "#8b4513", // Saddle Brown
-  "#00ffff", // Aqua
   "#ffd700", // Gold
+  "#ff1493", // Deep Pink
+  "#00ffff", // Aqua
+  "#20b2aa", // Light Sea Green
   "#4b0082", // Indigo
   "#ff8c00", // Dark Orange
-  "#dc143c", // Crimson
-  "#556b2f", // Dark Olive Green
+  "#008080", // Teal
+  "#ff0000", // Red
+  "#008000", // Green
+  "#9932cc", // Dark Orchid
 ];
 
 const useClusterColor = (clusterIds: string[]) => {

--- a/pipeline/steps/translation.py
+++ b/pipeline/steps/translation.py
@@ -36,7 +36,7 @@ def translation(config):
                "Showing", "arguments", "Reset zoom", "Click anywhere on the map to close this",
                "Click on the dot for details",
                "agree", "disagree", "Language", "English", "arguments", "of total",
-               "Overview", "Cluster analysis", "Representative comments", "Introduction",
+               "Project", "Overview", "Cluster analysis", "Representative comments", "Introduction",
                "Clusters", "Appendix", "This report was generated using an AI pipeline that consists of the following steps",
                "Step", "extraction", "show code", "hide code", "show prompt", "hide prompt", "embedding",
                "clustering", "labelling", "takeaways", "overview"]


### PR DESCRIPTION
Full-page styling tweaks, including:
- clearer two-column layout
- left-justified main content
- buttons
- more muted default colors

Putting language selector work in a follow-up (see https://github.com/AIObjectives/talk-to-the-city-reports/issues/25)


Representative screenshots (including unchanged full-screen map view):
![Screen Shot 2023-11-15 at 10 02 18](https://github.com/AIObjectives/talk-to-the-city-reports/assets/1048995/ae8c8507-602d-41fc-9fca-43b723e604e2)
![Screen Shot 2023-11-15 at 10 03 16](https://github.com/AIObjectives/talk-to-the-city-reports/assets/1048995/abcf06b6-e5a3-4716-a818-f95b3a61a4f6)
![Screen Shot 2023-11-15 at 10 02 57](https://github.com/AIObjectives/talk-to-the-city-reports/assets/1048995/27c47306-dbd0-4305-8949-d1ccec3ffce6)
![Screen Shot 2023-11-15 at 10 02 48](https://github.com/AIObjectives/talk-to-the-city-reports/assets/1048995/4f8c8c14-989b-4a05-b086-9687ba7239fb)
![Screen Shot 2023-11-15 at 10 02 41](https://github.com/AIObjectives/talk-to-the-city-reports/assets/1048995/bf161ec9-e09f-4768-b8d3-c13fb22c3b57)
![Screen Shot 2023-11-15 at 10 02 26](https://github.com/AIObjectives/talk-to-the-city-reports/assets/1048995/a43291a1-7b8b-4607-a19a-01905e03d821)

(note: large amount of right padding in the outline panel in French is an artifact of a cluster title being truncated right before a long word, "développement." we could fix this by truncating in the middle of words but I think it's ok for now)