### PR TITLE
Full-page font/margin changes for bar graph report view

### DIFF
--- a/turbo/package.json
+++ b/turbo/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tttc-turbo",
 	"version": "0.0.1",
-	"tsCoverage": "82%",
+	"tsCoverage": "83%",
 	"vitestPass": 186,
 	"vitestFail": 0,
 	"engines": {

--- a/turbo/src/components/report/Claims.svelte
+++ b/turbo/src/components/report/Claims.svelte
@@ -33,9 +33,9 @@
 	});
 </script>
 
-<div class="ml-5 mt-2"><h5>{$__('representative_arguments')}:</h5></div>
-<small class="ml-8 mb-5">{$__('click_on_argument_to_see_original_claim')}</small>
-<div class="ml-10 mt-3">
+<div class="mt-4"><h4>{$__('representative_arguments')}</h4></div>
+<small class="mb-5 italic">{$__('click_on_argument_to_see_original_claim')}</small>
+<div class="ml-4 mt-2">
 	{#each sortedClaims.slice(0, showMoreClaims ? sortedClaims.length : 5) as claim (claim.claim)}
 		<div class="flex items-center" style="color: black">
 			<div class="text-sm">
@@ -44,8 +44,15 @@
 		</div>
 	{/each}
 	{#if sortedClaims.length > 5}
-		<button on:click={() => (showMoreClaims = !showMoreClaims)}>
+		<button class="text-sm font-bold"
+		    on:click={() => (showMoreClaims = !showMoreClaims)}>
 			{showMoreClaims ? $__('show_less') : $__('show_more')}
 		</button>
 	{/if}
 </div>
+
+<style>
+	button {
+		color: var(--smui-primary);
+	}
+</style>

--- a/turbo/src/components/report/Description.svelte
+++ b/turbo/src/components/report/Description.svelte
@@ -23,7 +23,7 @@
 	</div>
 {:else}
 	<div
-		class="flex flex-col px-2 my-4 max-w-full mx-auto pl-8 mb-5 {!showDrawer
+		class="flex flex-col px-2 my-4 max-w-full mx-auto pl-10 mb-5 {!showDrawer
 			? 'lg:max-w-[800px]'
 			: ''}"
 		id="description"

--- a/turbo/src/components/report/Report.svelte
+++ b/turbo/src/components/report/Report.svelte
@@ -143,7 +143,9 @@
 </div>
 
 <!-- Bar Chart -->
-<div class="ml-8 mr-5 mb-7 mt-5">
+<!-- x-margins intentionally smaller than other report sections to keep all
+     text aligned while allowing for extra bar chart row padding on hover -->
+<div class="mx-8 mb-7 mt-5">
 	{#if $chartMode == 'bar'}
 		{#if complexHierarchy}
 			<BarChart {complexHierarchy} level="top" />
@@ -152,34 +154,38 @@
 </div>
 
 <!-- Report -->
-<div class="report-container" id="report-container">
+<div class="report-container mx-10 mt-12" id="report-container">
 	{#if report && report.topics}
 		{#each report.topics as topic}
 			{@const topicColor = hsl(ordinalColor(topic.topicName)).brighter(-1)}
-			<div id={_.kebabCase('report-' + topic.topicName)} style="scroll-margin-top: 45px" />
-			<div class="p-4 rounded">
+			<div id={_.kebabCase('report-' + topic.topicName)} class="mt-12 pt-4"
+			     style="scroll-margin-top: 45px" />
+			<!-- TODO scroll-margin-top above does not seem to affect scroll target;
+			     top padding added to position topic header on scroll -->
+			<div>
 				<!-- Topic title -->
-				<div style="display: flex; justify-content: space-between;">
+				<div class="flex justify-between">
 					<span style="max-width: 740px;">
-						<h3 class="text-2xl font-bold" style="color: {topicColor}">
+						<h2 class="text-2xl font-bold" style="color: {topicColor}">
 							{topic.topicName}
-						</h3>
+						</h2>
 					</span>
 					<a
 						href="javascript:void(0)"
 						on:click={() => {
 							document.getElementById('graph-container').scrollIntoView({ behavior: 'smooth' });
-						}}><p>{$__('back_to_overview')} <small>↑</small></p></a
-					>
+						}}>
+						<p>{$__('back_to_overview')}
+							<small style="vertical-align:text-bottom">↑</small>
+						</p>
+					</a>
 				</div>
 				<!-- Topic stats etc. -->
 				<small
-					style="padding-left: 5px; color: {hsl(ordinalColor(topic.topicName)).brighter(
+					style="padding-left: 2px; color: {hsl(ordinalColor(topic.topicName)).brighter(
 						-2
 					)};  max-width: 740px;"
 				>
-					{_.map(topic.subtopics.length.toString(), (c) => $__(c)).join('')}
-					{$__('subtopics')}
 					{_.map(
 						_.sumBy(
 							topic.subtopics,
@@ -188,14 +194,16 @@
 						).toString(),
 						(c) => $__(c)
 					).join('')}
-					{$__('claims')}
+					{$__('claims in')}
+					{_.map(topic.subtopics.length.toString(), (c) => $__(c)).join('')}
+					{$__('subtopics')}
 				</small>
 				<!-- Topic description -->
 				{#if topic.topicShortDescription}
 					<h6 class="mt-4 mb-4" style="max-width: 740px;">{topic.topicShortDescription}</h6>
 				{/if}
 				<!-- Topic Bar chart (of subtopics) -->
-				<div class="ml-8 mr-5 mb-7 mt-5">
+				<div class="mx-6 mt-5 mb-8">
 					{#if $chartMode == 'bar'}
 						{#if complexHierarchy}
 							<BarChart
@@ -208,24 +216,24 @@
 						{/if}
 					{/if}
 				</div>
+				<!-- Subtopics -->
 				{#each topic.subtopics as subtopic (subtopic.subtopicName)}
-					<br />
 					<div
 						id={_.kebabCase('report-' + subtopic.subtopicName)}
 						style="scroll-margin-top: 45px"
 					/>
 					<div
-						class="text-lg"
+						class="text-lg mt-8"
 						style="color: {topicColor}; display: flex; justify-content: space-between;"
 					>
-						<h5>{subtopic.subtopicName}</h5>
+						<h3>{subtopic.subtopicName}</h3>
 					</div>
-					<small style="padding-left: 5px;">
+					<small style="padding-left: 1px;">
 						{_.map(_.uniqBy(subtopic.claims, 'claim').length.toString(), (c) => $__(c)).join('')}
 						{$__('claims')}</small
 					>
 					{#if subtopic.subtopicShortDescription}
-						<div class="ml-5 mt-2 mb-2" style="color: black; max-width: 740px;">
+						<div class="my-2" style="max-width: 740px;">
 							<h7>{subtopic.subtopicShortDescription}</h7>
 						</div>
 					{/if}
@@ -237,10 +245,8 @@
 						}}
 						showFeedback={!!feedbackNode}
 					/>
-					<br />
 				{/each}
 			</div>
-			<br />
 		{/each}
 	{/if}
 </div>
@@ -270,11 +276,7 @@
 		gap: 16px; /* Optional: Add a gap if needed */
 		transition: all 0.5s ease-in-out; /* Smooth transition for the resizing */
 	}
-	.report-container {
-		padding: var(--main-padding);
-		width: 100%;
-		margin-left: 0;
-	}
+
 	.chart-wrapper {
 		/* Flex-grow allows the chart to grow and take up available space */
 		flex-grow: 1;

--- a/turbo/src/components/report/barChart/barChartRow.svelte
+++ b/turbo/src/components/report/barChart/barChartRow.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <button
-	class="flex-container"
+	class="flex-container px-2"
 	style="text-align: left;"
 	bind:clientWidth
 	bind:clientHeight
@@ -52,16 +52,16 @@
 		hovering = false;
 	}}
 >
-	<div class="flex-item text-section">
-		<h5>{complexHierarchy.data.name}</h5>
-		<p>
+	<div class="flex-item text-section py-2">
+		<h4>{complexHierarchy.data.name}</h4>
+		<small>
 			{_.truncate(description, { length: 150 })}
-		</p>
+		</small>
 	</div>
 	<svg class="separator" width="2" height={clientHeight}>
 		<line x1="1" y1="0" x2="1" y2={clientHeight} stroke="#ddd" stroke-width="1" />
 	</svg>
-	<svg height={height + 30} {width} class="flex-item bar-section">
+	<svg height={height + 46} {width} class="flex-item bar-section py-2">
 		<rect {width} {height} fill={_color} />
 		<text
 			x={textX}
@@ -73,7 +73,8 @@
 			font-weight="bold">{complexHierarchy.value + ' ' + $__('claims')}</text
 		>
 		{#if hovering}
-			<text x={textX} y={textY + 35} fill="black" dominant-baseline="middle" text-anchor="left"
+			<text x={textX} y={textY + 35} fill="black" dominant-baseline="middle"
+			text-anchor="left" font-size="small"
 				>{$__(level === 'top' ? 'click_to_view_topic' : 'click_to_view_subtopic')}</text
 			>
 		{/if}
@@ -85,7 +86,6 @@
 		display: flex;
 		align-items: stretch;
 		width: 100%;
-		padding-right: 10px;
 	}
 	.flex-item {
 		flex: 1;

--- a/turbo/src/lib/icons/Circle.svelte
+++ b/turbo/src/lib/icons/Circle.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let size = "1em";
+  export let size = ".8em";
   export let width = size;
   export let height = size;
   export let color = "currentColor";

--- a/turbo/src/routes/report/[report]/+layout.svelte
+++ b/turbo/src/routes/report/[report]/+layout.svelte
@@ -31,35 +31,25 @@
 <div class="drawer-container" class:standard-view={isStandard}>
 	{#if showDrawer}
 		<div id="drawerBackground">
-			<div class="custom-drawer hide-scrollbar">
-				<button
-					on:click={() => {
-						document.getElementById('description').scrollIntoView({ behavior: 'smooth' });
-					}}
-				>
-					<h3 style="padding-left: 10px;">{$__('contents')}</h3>
-				</button>
-				<br />
-				<button
+			<div class="custom-drawer mt-4 hide-scrollbar">
+				<button class="mt-2 block"
 					on:click={() => {
 						document.getElementById('graph-container').scrollIntoView({ behavior: 'smooth' });
 					}}
-					><h4 style="padding-left: 10px;">
+					><h5>
 						{$__('overview')}
-					</h4></button
+					</h5></button
 				>
-				<br />
-				<button
+				<button class="mt-2 nav-section"
 					on:click={() => {
 						document.getElementById('report-container').scrollIntoView({ behavior: 'smooth' });
 					}}
 				>
-					<h5 style="padding-left: 10px;">{$__('clusters')}</h5>
+					<h5>{$__('clusters')}</h5>
 				</button>
-				<br />
 				{#each $reportStore?.topics as topic}
 					<button
-						class="topic-item"
+						class="topic-item mt-2 block"
 						on:click={() => scrollToTopic(topic.topicName)}
 						on:mouseover={() => {
 							hoverColor = ('' + hsl(ordinalColor(topic.topicName)))
@@ -87,7 +77,7 @@
 					</button>
 					{#each topic.subtopics as subtopic}
 						<button
-							class="topic-item ml-4"
+							class="topic-item ml-6"
 							on:click={() => scrollToTopic(subtopic.subtopicName)}
 							on:mouseover={() => {
 								hoverColor = ('' + hsl(ordinalColor(subtopic.topicName)))
@@ -109,19 +99,16 @@
 							}}
 							type="button"
 						>
-							<span><Circle size="8px" color={'' + hsl(ordinalColor(topic.topicName))} /></span>
-							&nbsp;
 							<small>{_.truncate(subtopic.subtopicName, { length: 30 })}</small>
 						</button>
 					{/each}
 				{/each}
-				<br />
-				<button
+				<button class="mt-2 block"
 					on:click={() => {
 						document.getElementById('appendix').scrollIntoView({ behavior: 'smooth' });
 					}}
 				>
-					<h5 style="padding-left: 10px; padding-top: 10px; padding-bottom: 20px;">
+					<h5>
 						{$__('appendix')}
 					</h5>
 				</button>
@@ -138,7 +125,7 @@
 
 <style>
 	#drawerBackground {
-		background-color: lightGrey;
+		background-color: #f2f2f2;
 		width: 256px;
 		height: 100%;
 		position: fixed;
@@ -161,10 +148,10 @@
 	.custom-drawer {
 		width: inherit;
 		height: calc(100% - 50px);
-		margin-top: 10px;
-		padding-right: 15px;
+		padding: 0 1.5rem;
 		box-sizing: border-box;
 		overflow-y: auto;
+		color: rgba(0,0,0,.75);
 	}
 
 	.app-content {
@@ -184,7 +171,7 @@
 		display: flex;
 		align-items: center;
 		gap: 2px;
-		padding-left: 20px;
+		padding-left: .5rem;
 		cursor: pointer;
 		width: 100%;
 	}

--- a/turbo/src/routes/styles.css
+++ b/turbo/src/routes/styles.css
@@ -74,19 +74,22 @@ h1 {
 }
 
 h2 {
-	font-size: 2em !important;
+	font-size: 1.75em !important;
+	font-weight: bold;
 }
 
 h3 {
-	font-size: 1.75em !important;
+	font-size: 1.25em !important;
+	font-weight: bold;
 }
 
 h4 {
-	font-size: 1.5em !important;
+	font-size: 1em !important;
+	font-weight: bold;
 }
 
 h5 {
-	font-size: 1.25em !important;
+	font-size: 1em !important;
 }
 
 h6 {


### PR DESCRIPTION
Lots of tweaks to get the UI looking sleeker, described in #127:
- new hierarchy of h elements
- more consistent left margins
- a bunch of less important stuff is smaller
- use tailwind class-based styles when possible
- general parity increase with mocks in #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced layout and styling across various sections for improved readability and user experience.
- **Style**
	- Adjusted font sizes and weights for headings to improve visual hierarchy.
	- Updated button and layout styling for a more cohesive look.
	- Improved alignment and spacing within the `Bar Chart` and `Report` sections for better content organization.
- **Refactor**
	- Refined layout elements and visual presentation within the drawer container to enhance user interaction and content accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->