### PR TITLE
reposition right-side header elements

### DIFF
--- a/turbo/src/components/Header.svelte
+++ b/turbo/src/components/Header.svelte
@@ -20,7 +20,6 @@
 <div class="right-stack">
 	<Menu {user} />
 	{#if isStandard}
-		<div style="padding-right: 20px;" />
 		{#if !$user}
 			<span class="link">
 				<a href="/login" style="padding-right: 5px; padding-top: 7px; padding-bottom: 5px;"
@@ -29,8 +28,8 @@
 			</span>
 		{/if}
 		<LanguageSelector />
-		<div style="padding-right: 20px;" />
-		<a href="https://github.com/AIObjectives/talk-to-the-city-reports" target="_blank">
+		<a href="https://github.com/AIObjectives/talk-to-the-city-reports"
+		   target="_blank" class="mr-6">
 			<img src={github} alt="GitHub" class="github" />
 		</a>
 	{/if}
@@ -67,7 +66,7 @@
 	}
 	.right-stack {
 		position: fixed;
-		right: 0;
+		right: 16px;
 		top: 5px;
 		z-index: 11;
 		display: flex;
@@ -145,10 +144,6 @@
 	}
 
 	.github {
-		position: relative;
-		padding-right: 4px;
-		top: 2px;
-		width: 30px;
-		left: 5px;
+		width: 26px;
 	}
 </style>

--- a/turbo/src/components/LanguageSelector.svelte
+++ b/turbo/src/components/LanguageSelector.svelte
@@ -66,7 +66,7 @@
 	}
 
 	.lang-container {
-		padding-right: 10px;
+		padding-right: 16px;
 	}
 
 	.lang-container .select-container {

--- a/turbo/src/components/menu/menu_burger.svelte
+++ b/turbo/src/components/menu/menu_burger.svelte
@@ -8,7 +8,7 @@
 <button
 	on:click|stopPropagation={() => (showDropdown = !showDropdown)}
 	class="focus:outline-none burger"
-	style="padding-top: 7px"
+	style="padding-top: 4px"
 >
 	<MenuIcon size="30px" color={isStandard ? '#dedede' : '#000000'} />
 </button>


### PR DESCRIPTION
looks like this now

<img width="241" alt="Screen Shot 2024-02-13 at 21 32 12" src="https://github.com/AIObjectives/talk-to-the-city-reports/assets/1048995/1eafdbda-f868-4586-be8d-e44c3125fcb7">


<img width="278" alt="Screen Shot 2024-02-13 at 21 32 04" src="https://github.com/AIObjectives/talk-to-the-city-reports/assets/1048995/be6aeeee-5d06-45ca-8e56-a5981cb3ff74">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the header layout, including adjustments to the language selector position and GitHub link styling.
	- Modified the GitHub icon size for better visual appeal.
	- Enhanced the visual spacing in the language selector and menu button for improved user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->