### PR TITLE
Add switch to set report to Private/Public #181

### DIFF
--- a/turbo/package-lock.json
+++ b/turbo/package-lock.json
@@ -87,6 +87,7 @@
         "@smui/fab": "^7.0.0-beta.15",
         "@smui/icon-button": "^7.0.0-beta.15",
         "@smui/snackbar": "^7.0.0-beta.15",
+        "@smui/switch": "^7.0.0-beta.18",
         "@smui/tooltip": "^7.0.0-beta.15",
         "@sveltejs/adapter-auto": "^2.0.0",
         "@sveltejs/kit": "^1.27.4",
@@ -2575,6 +2576,27 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@material/switch": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-14.0.0.tgz",
+      "integrity": "sha512-vHVKzbvHVKGSrkMB1lZAl8z3eJ8sPRnSR+DWn+IhqHcTsDdDyly2NNj4i2vTSrEA39CztGqkx0OnKM4vkpiZHw==",
+      "dev": true,
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/density": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/focus-ring": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/tokens": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@material/tab": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@material/tab/-/tab-14.0.0.tgz",
@@ -3038,9 +3060,9 @@
       }
     },
     "node_modules/@smui/common": {
-      "version": "7.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.16.tgz",
-      "integrity": "sha512-PpqhIAWtE6ZZ6XyIkzHGXdMk+iE4QLFdzYXf20cG13O/0bFjOV5ySk2g+Vq2ZWRJawIjMaPcekbCkkowna4vgg==",
+      "version": "7.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.18.tgz",
+      "integrity": "sha512-BH70iF23eGKK57YReDG5nerJR/7lomncVAcKCJ35KEso90S+eu7lZwDg5kUdzVzDRNdS+WkTrDKPhKmo3R2sEQ==",
       "dependencies": {
         "@material/dom": "^14.0.0",
         "svelte2tsx": "^0.6.27"
@@ -3201,13 +3223,13 @@
       }
     },
     "node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.16.tgz",
-      "integrity": "sha512-HULlv8zdEOvexw9Ob7senmk8cAuHZ3usaCruWclOSVBesKHDIODRpIusFCnoFv2Gk4PVjsDRCIvk1lzRWRjEUQ==",
+      "version": "7.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.18.tgz",
+      "integrity": "sha512-HegU/75nnaORFwrhojzeyYW4M9FD1nh59zgaWkw3lJK61wbo3bPmIkjPnytpItZXW4GsZfTRJ1ooCr9iiX1otQ==",
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.16",
+        "@smui/common": "^7.0.0-beta.18",
         "svelte2tsx": "^0.6.27"
       }
     },
@@ -3258,6 +3280,20 @@
         "@smui/icon-button": "^7.0.0-beta.15",
         "@smui/ripple": "^7.0.0-beta.15",
         "svelte2tsx": "^0.6.21"
+      }
+    },
+    "node_modules/@smui/switch": {
+      "version": "7.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@smui/switch/-/switch-7.0.0-beta.18.tgz",
+      "integrity": "sha512-5kGy0oLoIniNSVYZE8or1OclHa4AAyrgG5dLT7f0X1svZX9lvTpj7a6Jk16d1x7ToeQpaNgFxynmmYSgZLJ/uA==",
+      "dev": true,
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "@material/switch": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.18",
+        "@smui/ripple": "^7.0.0-beta.18",
+        "svelte2tsx": "^0.6.27"
       }
     },
     "node_modules/@smui/tab": {
@@ -18351,6 +18387,27 @@
         "tslib": "^2.1.0"
       }
     },
+    "@material/switch": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-14.0.0.tgz",
+      "integrity": "sha512-vHVKzbvHVKGSrkMB1lZAl8z3eJ8sPRnSR+DWn+IhqHcTsDdDyly2NNj4i2vTSrEA39CztGqkx0OnKM4vkpiZHw==",
+      "dev": true,
+      "requires": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/density": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/focus-ring": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/tokens": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "@material/tab": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@material/tab/-/tab-14.0.0.tgz",
@@ -18791,9 +18848,9 @@
       }
     },
     "@smui/common": {
-      "version": "7.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.16.tgz",
-      "integrity": "sha512-PpqhIAWtE6ZZ6XyIkzHGXdMk+iE4QLFdzYXf20cG13O/0bFjOV5ySk2g+Vq2ZWRJawIjMaPcekbCkkowna4vgg==",
+      "version": "7.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.18.tgz",
+      "integrity": "sha512-BH70iF23eGKK57YReDG5nerJR/7lomncVAcKCJ35KEso90S+eu7lZwDg5kUdzVzDRNdS+WkTrDKPhKmo3R2sEQ==",
       "requires": {
         "@material/dom": "^14.0.0",
         "svelte2tsx": "^0.6.27"
@@ -18954,13 +19011,13 @@
       }
     },
     "@smui/ripple": {
-      "version": "7.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.16.tgz",
-      "integrity": "sha512-HULlv8zdEOvexw9Ob7senmk8cAuHZ3usaCruWclOSVBesKHDIODRpIusFCnoFv2Gk4PVjsDRCIvk1lzRWRjEUQ==",
+      "version": "7.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.18.tgz",
+      "integrity": "sha512-HegU/75nnaORFwrhojzeyYW4M9FD1nh59zgaWkw3lJK61wbo3bPmIkjPnytpItZXW4GsZfTRJ1ooCr9iiX1otQ==",
       "requires": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.16",
+        "@smui/common": "^7.0.0-beta.18",
         "svelte2tsx": "^0.6.27"
       }
     },
@@ -19011,6 +19068,20 @@
         "@smui/icon-button": "^7.0.0-beta.15",
         "@smui/ripple": "^7.0.0-beta.15",
         "svelte2tsx": "^0.6.21"
+      }
+    },
+    "@smui/switch": {
+      "version": "7.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@smui/switch/-/switch-7.0.0-beta.18.tgz",
+      "integrity": "sha512-5kGy0oLoIniNSVYZE8or1OclHa4AAyrgG5dLT7f0X1svZX9lvTpj7a6Jk16d1x7ToeQpaNgFxynmmYSgZLJ/uA==",
+      "dev": true,
+      "requires": {
+        "@material/feature-targeting": "^14.0.0",
+        "@material/switch": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.18",
+        "@smui/ripple": "^7.0.0-beta.18",
+        "svelte2tsx": "^0.6.27"
       }
     },
     "@smui/tab": {

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -38,6 +38,7 @@
     "@smui/fab": "^7.0.0-beta.15",
     "@smui/icon-button": "^7.0.0-beta.15",
     "@smui/snackbar": "^7.0.0-beta.15",
+    "@smui/switch": "^7.0.0-beta.18",
     "@smui/tooltip": "^7.0.0-beta.15",
     "@sveltejs/adapter-auto": "^2.0.0",
     "@sveltejs/kit": "^1.27.4",

--- a/turbo/src/components/report/Description.svelte
+++ b/turbo/src/components/report/Description.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Switch from '@smui/switch';
   import Checkbox from '@smui/checkbox';
   import FormField from '@smui/form-field';
   import HelperText from '@smui/textfield/helper-text';
@@ -10,6 +11,9 @@
 
   export let dataset;
   let editing = false;
+  let isPublic = !dataset.isPrivate;
+
+  $: dataset.isPrivate = !isPublic;
 
   $: isStandard = $globalViewMode === 'standard';
   $: showDrawer = isStandard && $reportStore?.topics?.length > 0;
@@ -41,6 +45,12 @@
       </div>
       <span slot="label">{$__('enable_forking')}</span>
     </FormField>
+    <div class='w-full px-3 py-5'>
+      <FormField>
+        <Switch bind:checked={isPublic} />
+        <span slot="label">{$__(isPublic ? 'public' : 'private')}</span>
+      </FormField>
+    </div>
     <button on:click={() => (editing = false)}>{$__('done')}</button>
   </div>
 {:else}

--- a/turbo/src/components/report/Report.svelte
+++ b/turbo/src/components/report/Report.svelte
@@ -222,7 +222,7 @@
           {/if}
         </div>
         <!-- Subtopics -->
-        {#each topic.subtopics as subtopic (subtopic.subtopicName)}
+        {#each topic.subtopics as subtopic (subtopic.subtopicName + subtopic.claims.length)}
           <div
             id={_.kebabCase('report-' + subtopic.subtopicName)}
             style="scroll-margin-top: 45px"

--- a/turbo/src/lib/dataset.ts
+++ b/turbo/src/lib/dataset.ts
@@ -38,6 +38,7 @@ export class Dataset {
   id?: string;
   projectParent?: string;
   enableForking: boolean = true;
+  isPrivate: boolean = false;
 
   constructor(
     projectTitle: string,
@@ -48,7 +49,8 @@ export class Dataset {
     graph: any,
     id?: string,
     projectParent?: string,
-    enableForking: boolean = true
+    enableForking: boolean = true,
+    isPrivate: boolean = false
   ) {
     this.title = projectTitle;
     this.slug = projectSlug;
@@ -60,6 +62,7 @@ export class Dataset {
     this.id = id;
     this.projectParent = projectParent;
     this.enableForking = enableForking;
+    this.isPrivate = isPrivate;
   }
 
   propagateDirtyState() {
@@ -392,7 +395,9 @@ export class Dataset {
       doc.description,
       doc.graph,
       id,
-      doc.projectParent
+      doc.projectParent,
+      doc.enableForking,
+      doc.isPrivate
     );
   }
 
@@ -405,7 +410,9 @@ export class Dataset {
       timestamp: this.timestamp,
       description: this.description,
       graph: { nodes: get(this.graph.nodes), edges: get(this.graph.edges) },
-      projectParent: this.projectParent
+      projectParent: this.projectParent,
+      enableForking: this.enableForking,
+      isPrivate: this.isPrivate
     };
   }
 
@@ -427,12 +434,14 @@ export class Dataset {
             doc.description,
             doc.graph,
             id,
-            doc.projectParent
+            doc.projectParent,
+            doc.enableForking,
+            doc.isPrivate
           );
           dataset.sanitize();
           await dataset.graph.conform(false, false, false);
-          // console.log('nodes', get(dataset.graph.nodes));
-          // console.log('edges', get(dataset.graph.edges));
+          console.log('nodes', get(dataset.graph.nodes));
+          console.log('edges', get(dataset.graph.edges));
           return dataset;
         }
       } catch (e) {
@@ -464,7 +473,9 @@ export class Dataset {
         timestamp: serverTimestamp(),
         description: this.description,
         graph: { nodes: get(this.graph.nodes), edges: get(this.graph.edges) },
-        projectParent: this.projectParent
+        projectParent: this.projectParent,
+        enableForking: this.enableForking,
+        isPrivate: this.isPrivate
       });
 
       this.id = docs.id;

--- a/turbo/src/lib/i18n/en-US.json
+++ b/turbo/src/lib/i18n/en-US.json
@@ -268,5 +268,8 @@
   "show_function_calls": "Show Function Calls",
   "enable_forking": "Enable Forking",
   "forking_disabled": "Forking Disabled",
-  "chat_is_restricted_to_dataset_owner": "Chat is restricted to dataset owner"
+  "chat_is_restricted_to_dataset_owner": "Chat is restricted to dataset owner",
+  "report_is_private": "Report is private",
+  "private": "Private",
+  "public": "Public"
 }

--- a/turbo/src/lib/i18n/zh-TW.json
+++ b/turbo/src/lib/i18n/zh-TW.json
@@ -270,5 +270,8 @@
   "speech_to_text": "語音轉文字",
   "dirty": "骯髒",
   "show_function_calls": "顯示函數呼叫",
-  "chat_is_restricted_to_dataset_owner": "聊天僅限於數據集擁有者"
+  "chat_is_restricted_to_dataset_owner": "聊天僅限於數據集擁有者",
+  "report_is_private": "報告是私有的",
+  "private": "私有",
+  "public": "公共"
 }

--- a/turbo/src/routes/new-report/+page.svelte
+++ b/turbo/src/routes/new-report/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import FormField from '@smui/form-field';
+  import Switch from '@smui/switch';
   import Button from '@smui/button';
   import HelperText from '@smui/textfield/helper-text';
   import { type DocumentData } from 'firebase/firestore';
@@ -140,6 +142,7 @@
   let projectTemplate = 'default';
   let templates: Record<string, DocumentData> = {};
   let templatesLoaded: boolean = false;
+  let isPublic: boolean = true;
 
   function createProjectSlug(str: string): string {
     return str
@@ -161,7 +164,9 @@
       projectDescription,
       graph,
       '',
-      ''
+      '',
+      true,
+      !isPublic
     );
 
     const successFlag = await newDataset.addDatasetToFirebase();
@@ -191,7 +196,7 @@
       <div class="w-full px-3 py-5">
         <TextField style="width: 100%;" bind:value={projectSlug} label={$__('report_url_path')}>
           <HelperText persistent slot="helper"
-            >https://tttc-turbo.web.app/report/{projectSlug}</HelperText
+            >https://talktothecity.org/report/{projectSlug}</HelperText
           >
         </TextField>
       </div>
@@ -200,11 +205,17 @@
           <HelperText persistent slot="helper">{$__('report_description')}</HelperText>
         </TextField>
       </div>
+      <div class='w-full px-3 py-5'>
+        <FormField>
+          <Switch bind:checked={isPublic} />
+          <span slot="label">{$__(isPublic ? 'public' : 'private')}</span>
+        </FormField>
+      </div>
+    </div>
       {#if templatesLoaded}
         <button class="w-full px-3 pt-5" on:click={createNewProject}>
           <Button type="submit">{$__('create')}</Button>
         </button>
       {/if}
     </div>
-  </div>
 </div>

--- a/turbo/src/routes/report/[report]/+page.svelte
+++ b/turbo/src/routes/report/[report]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { user } from '$lib/store';
   import { getContext } from 'svelte';
   import { type Writable } from 'svelte/store';
   import { _ as __ } from 'svelte-i18n';
@@ -21,6 +22,8 @@
 <main id="report-main">
   {#if !dataset}
     <p class="text-center text-lg text-gray-500">{$__('loading')}</p>
+  {:else if dataset?.isPrivate && dataset?.owner !== $user?.uid}
+    <p class="text-center text-lg text-gray-500">{$__('report_is_private')}</p>
   {:else}
     {#if $globalViewMode == 'standard'}
       <Description bind:dataset />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added privacy settings for reports, allowing them to be marked as public or private.
	- Integrated new localization keys to support English and Traditional Chinese for the new privacy feature.

- **Enhancements**
	- Improved report generation logic to handle subtopics more efficiently.

- **User Interface**
	- Introduced a toggle switch in the report creation interface to select between public and private settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->