### PR TITLE
FIX: LLM sometimes returns string and the code handle it as list

### DIFF
--- a/scatter/pipeline/steps/extraction.py
+++ b/scatter/pipeline/steps/extraction.py
@@ -47,8 +47,13 @@ def extract_arguments(input, prompt, model, retries=3):
     llm = ChatOpenAI(model_name=model, temperature=0.0)
     response = llm(messages=messages(prompt, input)).content.strip()
     try:
-        parsed = [a.strip() for a in json.loads(response)]
-        return parsed
+        obj = json.loads(response)
+        # LLM sometimes returns valid JSON string
+        if isinstance(obj, str):
+            obj = [obj]
+        items = [a.strip() for a in obj]
+        items = filter(None, items)  # omit empty strings
+        return items
     except json.decoder.JSONDecodeError as e:
         print("JSON error:", e)
         print("Input was:", input)


### PR DESCRIPTION
LLM sometimes returns a valid JSON string. In such cases, the original code mistakenly treats the string as a list and outputs it character by character.

This causes an error `TypeError: expected string or buffer` in the next embedding phase.

![image](https://github.com/AIObjectives/talk-to-the-city-reports/assets/315198/16f4f147-4a01-460b-b6d8-a09cb516a9a6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of responses from ChatOpenAI to ensure compatibility with both JSON arrays and strings, enhancing the reliability of argument extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->