### PR TITLE
Fix: typo 'current_jop_tasks' -> 'current_job_tasks' in utils.py

### DIFF
--- a/scatter/pipeline/utils.py
+++ b/scatter/pipeline/utils.py
@@ -231,7 +231,7 @@ def update_progress(config, incr=None, total=None):
     if total is not None:
         update_status(config, {
             'current_job_progress': 0,
-            'current_jop_tasks': total
+            'current_job_tasks': total
         })
     elif incr is not None:
         update_status(config, {
@@ -256,7 +256,7 @@ def run_step(step, func, config):
     # update status after running...
     update_status(config, {
         'current_job_progress': None,
-        'current_jop_tasks': None,
+        'current_job_tasks': None,
         'completed_jobs': config.get('completed_jobs', []) + [{
             'step': step,
             'completed': datetime.now().isoformat(),


### PR DESCRIPTION
I found a small typo in the progress tracking code and would like to propose this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved job progress tracking by correcting a naming inconsistency to ensure accurate monitoring of task status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->