### PR TITLE
T3C-413: Update README to point to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Talk to the City
 
+**Active development of Talk to the City now occurs at [tttc-light-js](https://github.com/AIObjectives/tttc-light-js/)**
+This repository will soon be made read-only and archived.
+
+
+
+---
+
 This repo is now a merged monorepo containing:
 
 ## Talk to the City Turbo

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Talk to the City
+# Talk to the City ![deprecated](https://img.shields.io/badge/status-deprecated-red.svg)
 
 **Active development of Talk to the City now occurs at [tttc-light-js](https://github.com/AIObjectives/tttc-light-js/)**
 This repository will soon be made read-only and archived.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to include a "deprecated" badge and a prominent notice about active development moving to a new repository, with a link provided and information about the current repository becoming read-only and archived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->